### PR TITLE
[Bugfix] Adding Param for avoid recreation of t3fetch-Dir

### DIFF
--- a/Classes/Command/FetchWebsiteCommand.php
+++ b/Classes/Command/FetchWebsiteCommand.php
@@ -39,7 +39,7 @@ class FetchWebsiteCommand extends Command
         exec('rm -rf ' . $fetchDirectory);
 
         // Create fetch directory
-        exec('mkdir ' . $fetchDirectory);
+        exec('mkdir -p ' . $fetchDirectory);
 
         // Fetch website recursively
         exec('wget --delete-after -q -r ' . $input->getArgument('baseUrl') . ' -R "' . self::REJECT . '" -P ' . $fetchDirectory, $output, $status);


### PR DESCRIPTION
Fetching multiple Domains (in multiple crons) causes an error message that the t3fetch Directory is not empty and can't be removed/recreated.